### PR TITLE
Remove ESLint 10 ignore from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 3
-    ignore:
-      - dependency-name: "eslint"
-        versions:
-          - "10"
     groups:
       astro:
         patterns:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `eslint` version 10 ignore from Dependabot now that the project has adopted ESLint 10.

Also cleaned up the stale `dependabot/npm_and_yarn/eslint-plugin-astro-2.1.0` branch (superseded by #429).

## Test plan

- [x] Config change only — no runtime impact
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2898-29f6-7d84-86d3-7030e1d48cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2898-29f6-7d84-86d3-7030e1d48cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

