### PR TITLE
Ignore TypeScript major updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    ignore:
+      # TypeScript 7 is the native compiler, which doesn't yet ship the
+      # programmatic API that @astrojs/language-server (astro check) relies on,
+      # so `npm run type-check` fails on it. Remove once Astro supports TS 7.
+      # https://github.com/withastro/astro/pull/17345
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Holds `typescript` on the 6.x line by ignoring major updates in `.github/dependabot.yml`.

## Why

TypeScript 7 is the native (Go) compiler port. It ships platform binaries, drops the `tsserver` bin, and does not yet expose the programmatic API that `@astrojs/language-server` relies on, so `npm run type-check` (`astro check`) crashes:

```
Cannot read properties of undefined (reading 'fileExists')
  at AstroCheck.getTsconfig (node_modules/@astrojs/language-server/dist/check.js:162:73)
```

That's what fails CI on #439. Astro acknowledged this upstream in language-server 2.16.12 (withastro/astro#17345) — `astro check` now fails early with a clear message instead of an opaque crash, because the native compiler doesn't ship the API the checker needs. So this is blocked on Astro, not on anything fixable here.

## Changes

- Add an `ignore` entry for `typescript` / `version-update:semver-major`, with a comment linking the upstream PR so it's clear when the rule can be dropped.

Minor and patch TypeScript updates still flow through the existing `dependencies` group. Dependabot should close #439 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfT5FUc5EU8EEnD6D32x91

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfT5FUc5EU8EEnD6D32x91)_